### PR TITLE
Add testload to basiliskRun()

### DIFF
--- a/R/drQuality.R
+++ b/R/drQuality.R
@@ -160,7 +160,8 @@ drQuality <- function(object, dimred = reducedDimNames(object),
         res <- basiliskRun(env = fmsneenv,
                            fun = .run_eval_dr_quality_from_list,
                            x = x,
-                           y = ys)
+                           y = ys,
+                           testload = "numba")
 
     } else {
         Kup <- as.integer(Kup)
@@ -174,7 +175,8 @@ drQuality <- function(object, dimred = reducedDimNames(object),
                         fun = .run_eval_red_rnx_auc_from_data,
                         x = x,
                         y = y,
-                        Kup = Kup)
+                        Kup = Kup,
+                        testload = "numba")
         }, BPPARAM = BPPARAM)
     }
     ## Convert list output to a data.frame

--- a/R/fmssne.R
+++ b/R/fmssne.R
@@ -36,7 +36,8 @@
                        maxcor = maxcor,
                        fit_U = fit_U,
                        bht = bht,
-                       fseed = fseed)
+                       fseed = fseed,
+                       testload = "numba")
     rownames(ans) <- rownames(x)
     colnames(ans) <- paste0("FMSSNE", seq_len(ncomponents))
     ans

--- a/R/fmstsne.R
+++ b/R/fmstsne.R
@@ -37,7 +37,8 @@
                        maxls = maxls,
                        maxcor = maxcor,
                        bht = bht,
-                       fseed = fseed)
+                       fseed = fseed,
+                       testload = "numba")
     rownames(ans) <- rownames(x)
     colnames(ans) <- paste0("FMSTSNE", seq_len(ncomponents))
     ans

--- a/R/internal.R
+++ b/R/internal.R
@@ -23,7 +23,8 @@
 ##' @importFrom reticulate import
 ##' @importFrom basilisk basiliskStart basiliskRun basiliskStop
 fmsnePythonNames <- function() {
-    cl <- basiliskStart(fmsneenv)
+    cl <- basiliskStart(fmsneenv,
+                        testload = "numba")
     fmsne.names <- basiliskRun(cl, function() {
         X <- reticulate::import("fmsne")
         names(X)
@@ -37,5 +38,6 @@ fmsnePythonVersion <- function() {
                 fun = function() {
                     fmsne <- reticulate::import("fmsne")
                     fmsne$`__version__`
-                })
+                },
+                testload = "numba")
 }

--- a/R/mssne.R
+++ b/R/mssne.R
@@ -30,7 +30,8 @@
                        ftol = ftol,
                        maxls = maxls,
                        maxcor = maxcor,
-                       fit_U = fit_U)
+                       fit_U = fit_U,
+                       testload = "numba")
     rownames(ans) <- rownames(x)
     colnames(ans) <- paste0("MSSNE", seq_len(ncomponents))
     ans

--- a/R/mstnse.R
+++ b/R/mstnse.R
@@ -29,7 +29,8 @@
                        gtol = gtol,
                        ftol = ftol,
                        maxls = maxls,
-                       maxcor = maxcor)
+                       maxcor = maxcor,
+                       testload = "numba")
     rownames(ans) <- rownames(x)
     colnames(ans) <- paste0("MSTSNE", seq_len(ncomponents))
     ans


### PR DESCRIPTION
This PR adds a `testload` argument to the `basiliskRun()`/`basiliskStart()` calls, to allow execution also if `GLIBCXX` dynamic linking fails. From the `basilisk` documentation: 

> `testload` - Character vector specifying the Python packages to load into the process during set-up. This is used to check that packages can be correctly loaded, switching to a fallback on GLIBCXX dynamic linking failures.

See [here](https://github.com/LTLA/basilisk/issues/20#issuecomment-1234484771) and [here](https://github.com/LTLA/basilisk/issues/20#issuecomment-1237336558) for more details. 